### PR TITLE
Fix Deprecated Test Strategy

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,5 +17,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'default'
+  config.order = 'defined'
 end


### PR DESCRIPTION
This pull request includes a small change to the RSpec configuration in the `spec/spec_helper.rb` file. The change updates the test order from `'default'` to `'defined'` due to default being deprecated